### PR TITLE
feat: project media folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 RocketBlend Desktop is designed to elevate your [Blender](https://www.blender.org/) workflow by simplifying dependency management, and enhancing the discoverability of local projects.
 
-It streamlines the management of Blender builds and addons, ensures smooth handling of project dependencies powered by [RocketBlend](https://github.com/rocketblend/rocketblend), and provides tools to efficiently organize and access your `.blend` projects. Project data is conveniently stored in `.yaml` files alongside your `.blend` files, enabling easy project sharing and synchronization.
+It streamlines the management of Blender builds and addons, ensures smooth handling of project dependencies powered by [RocketBlend](https://github.com/rocketblend/rocketblend), and provides tools to efficiently organize and access your `.blend` projects.
 
 > [!NOTE]  
 > **Important:** RocketBlend Desktop is currently under active development and still evolving. As such, expect significant changes, potential bugs, and incomplete features. We recommend holding off on using it until it reaches a more stable release.

--- a/frontend/src/lib/components/utils.ts
+++ b/frontend/src/lib/components/utils.ts
@@ -7,14 +7,6 @@ export function debounce(fn: Function, delay: number) {
     };
 }
 
-export function resourcePath(path: string | undefined) {
-    if (path && path != "") {
-        return `/system/${path}`;
-    }
-
-    return "";
-};
-
 export const videoExtensions = ['.webm', '.mp4', '.ogg'];
 export function isVideo(path: string) {
     return videoExtensions.some(ext => path.endsWith(ext));

--- a/frontend/src/lib/wailsjs/go/models.ts
+++ b/frontend/src/lib/wailsjs/go/models.ts
@@ -679,6 +679,20 @@ export namespace types {
 	        this.max = source["max"];
 	    }
 	}
+	export class Media {
+	    filePath: string;
+	    url: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new Media(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.filePath = source["filePath"];
+	        this.url = source["url"];
+	    }
+	}
 	export class Operation {
 	    id: number[];
 	    completed: boolean;
@@ -763,11 +777,13 @@ export namespace types {
 	    name: string;
 	    tags: string[];
 	    path: string;
+	    mediaPath: string;
 	    fileName: string;
 	    build: string;
 	    addons: string[];
-	    splashPath: string;
-	    thumbnailPath: string;
+	    splash?: Media;
+	    thumbnail?: Media;
+	    media: Media[];
 	    version: string;
 	    // Go type: time
 	    updatedAt: any;
@@ -782,11 +798,13 @@ export namespace types {
 	        this.name = source["name"];
 	        this.tags = source["tags"];
 	        this.path = source["path"];
+	        this.mediaPath = source["mediaPath"];
 	        this.fileName = source["fileName"];
 	        this.build = source["build"];
 	        this.addons = source["addons"];
-	        this.splashPath = source["splashPath"];
-	        this.thumbnailPath = source["thumbnailPath"];
+	        this.splash = this.convertValues(source["splash"], Media);
+	        this.thumbnail = this.convertValues(source["thumbnail"], Media);
+	        this.media = this.convertValues(source["media"], Media);
 	        this.version = source["version"];
 	        this.updatedAt = this.convertValues(source["updatedAt"], null);
 	    }

--- a/frontend/src/routes/(components)/footer/footer.svelte
+++ b/frontend/src/routes/(components)/footer/footer.svelte
@@ -4,8 +4,6 @@
     import { type types, application } from '$lib/wailsjs/go/models';
     import { RunProject, OpenExplorer } from '$lib/wailsjs/go/application/Driver';
 
-    import { resourcePath } from '$lib/components/utils';
-
     import FooterContent from './footer-content.svelte';
 
     export let selected: types.Project | undefined;

--- a/frontend/src/routes/(components)/footer/footer.svelte
+++ b/frontend/src/routes/(components)/footer/footer.svelte
@@ -40,7 +40,7 @@
 <FooterContent
     name={selected?.name}
     fileName={selected?.fileName}
-    imagePath={resourcePath(selected?.thumbnailPath)}
+    imagePath={selected?.thumbnail?.url}
     isLoading={!selected}
     on:viewProject={handleViewProject}
     on:runProject={handleRunProject}

--- a/frontend/src/routes/projects/(components)/project/project-list.svelte
+++ b/frontend/src/routes/projects/(components)/project/project-list.svelte
@@ -2,7 +2,6 @@
     import type { types } from '$lib/wailsjs/go/models';
 
     import { DisplayType, type MediaInfo } from '$lib/types';
-    import { resourcePath } from '$lib/components/utils';
     import { GalleryGrid } from '$lib/components/ui/gallery';
     
     import ProjectTable from "./project-table.svelte";

--- a/frontend/src/routes/projects/(components)/project/project-list.svelte
+++ b/frontend/src/routes/projects/(components)/project/project-list.svelte
@@ -14,9 +14,9 @@
     function convertProjectsToGalleryItems(projects: types.Project[] = []): MediaInfo[] {
         return projects.map((project) => ({
             id: project.id?.toString() || "",
-            title: project.name || "Untitled Project",
-            alt: `${project.name || "Untitled Project"} splash`,
-            src: resourcePath(project.splashPath)
+            title: project.name || "",
+            alt: `${project.name || ""} splash`,
+            src: project.splash?.url || "",
         }));
     }
 

--- a/frontend/src/routes/projects/[id]/+page.svelte
+++ b/frontend/src/routes/projects/[id]/+page.svelte
@@ -69,7 +69,7 @@
 <main class="space-y-4"> 
     <div class="flex gap-4 items-end">
         <div>
-            <Media src={resourcePath(data.project.thumbnailPath)} alt="" />
+            <Media src={data.project.thumbnail?.url} alt="" />
         </div>
         <div class="space-y-2">
             <InputInline bind:value={data.project.name} labelClasses="h2 font-bold items-baseline" inputClasses="input" on:change={handleChange}>
@@ -92,6 +92,8 @@
     <InlineInput type="textarea" placeholder="Add description..."/> -->
     <hr>
     <div class="grid grid-cols-4 gap-4">
-        <Media height="80" width="full" src={resourcePath(data.project.splashPath)} />
+        {#each data.project.media || [] as media}
+            <Media height="80" width="full" src={media.url} alt="" />
+        {/each}
       </div>
 </main>

--- a/frontend/src/routes/projects/[id]/+page.svelte
+++ b/frontend/src/routes/projects/[id]/+page.svelte
@@ -9,7 +9,7 @@
 
     import { t } from '$lib/translations/translations';
     import { getSelectedProjectStore } from '$lib/stores';
-    import { formatDateTime, resourcePath } from '$lib/components/utils';
+    import { formatDateTime } from '$lib/components/utils';
     import { Media } from '$lib/components/ui/media';
     import { InputInline } from '$lib/components/ui/input';
 

--- a/internal/application/project/get.go
+++ b/internal/application/project/get.go
@@ -4,13 +4,31 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
+	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/uuid"
+	"github.com/rocketblend/rocketblend-desktop/internal/application/fileserver"
 	"github.com/rocketblend/rocketblend-desktop/internal/application/store/indextype"
 	"github.com/rocketblend/rocketblend-desktop/internal/application/types"
 )
+
+var validMediaExtensions = map[string]struct{}{
+	".jpg":  {},
+	".jpeg": {},
+	".png":  {},
+	".gif":  {},
+	".bmp":  {},
+	".svg":  {},
+	".webp": {},
+	".webm": {},
+}
+
+var splashKeyWord = "splash"
+var thumbnailKeyWord = "thumbnail"
 
 func (r *Repository) GetProject(ctx context.Context, opts *types.GetProjectOpts) (*types.GetProjectResponse, error) {
 	result, err := r.get(ctx, opts.ID)
@@ -52,10 +70,10 @@ func convertToIndex(project *types.Project) (*types.Index, error) {
 		return nil, err
 	}
 
-	resources := []string{}
-	if project.ThumbnailPath != "" {
-		resources = append(resources, filepath.ToSlash(project.ThumbnailPath))
-		resources = append(resources, filepath.ToSlash(project.SplashPath))
+	// TODO: need a better way to register resources for the http server.
+	resources := make([]string, 0, len(project.Media))
+	for _, m := range project.Media {
+		resources = append(resources, filepath.ToSlash(m.FilePath))
 	}
 
 	return &types.Index{
@@ -66,4 +84,58 @@ func convertToIndex(project *types.Project) (*types.Index, error) {
 		Resources: resources,
 		Data:      string(data),
 	}, nil
+}
+
+func findMediaFiles(path string) ([]*types.Media, error) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	var files []*types.Media
+	visit := func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil // skip directories
+		}
+
+		ext := strings.ToLower(filepath.Ext(path))
+		if _, found := validMediaExtensions[ext]; found {
+			media, err := loadMedia(path)
+			if err != nil {
+				return err
+			}
+
+			files = append(files, media)
+		}
+
+		return nil
+	}
+
+	err := filepath.WalkDir(path, visit)
+	if err != nil {
+		return nil, err
+	}
+
+	return files, nil
+}
+
+func loadMedia(path string) (*types.Media, error) {
+	return &types.Media{
+		FilePath: path,
+		URL:      "/" + filepath.ToSlash(filepath.Join(fileserver.DynamicResourcePath, path)),
+	}, nil
+}
+
+func containsWordInFilename(path string, word string) bool {
+	filename := filepath.Base(path)
+	lowerFilename := strings.ToLower(filename)
+	lowerWord := strings.ToLower(word)
+	return strings.Contains(lowerFilename, lowerWord)
 }

--- a/internal/application/project/update.go
+++ b/internal/application/project/update.go
@@ -22,14 +22,6 @@ func (r *Repository) UpdateProject(ctx context.Context, opts *types.UpdateProjec
 		detail.Tags = *opts.Tags
 	}
 
-	if opts.ThumbnailPath != nil {
-		detail.ThumbnailPath = *opts.ThumbnailPath
-	}
-
-	if opts.SplashPath != nil {
-		detail.SplashPath = *opts.SplashPath
-	}
-
 	if err := r.saveDetail(project.Path, detail); err != nil {
 		return err
 	}

--- a/internal/application/types/detail.go
+++ b/internal/application/types/detail.go
@@ -14,11 +14,9 @@ type (
 	// }
 
 	Detail struct {
-		ID   uuid.UUID `json:"id"`
-		Name string    `json:"name"`
-		Tags []string  `json:"tags,omitempty"`
-		//ThumbnailSettings *ThumbnailSettings `json:"thumbnailSettings,omitempty"`
-		ThumbnailPath string `json:"thumbnailPath,omitempty"`
-		SplashPath    string `json:"splashPath,omitempty"`
+		ID        uuid.UUID `json:"id"`
+		Name      string    `json:"name"`
+		Tags      []string  `json:"tags,omitempty"`
+		MediaPath string    `json:"mediaPath,omitempty"`
 	}
 )

--- a/internal/application/types/project.go
+++ b/internal/application/types/project.go
@@ -13,20 +13,31 @@ import (
 const IgnoreFileName = ".rocketignore"
 
 type (
+	Media struct {
+		FilePath string `json:"filePath"`
+		URL      string `json:"url"`
+		// Height    int    `json:"height"`
+		// Width     int    `json:"width"`
+	}
+
 	Project struct {
-		ID       uuid.UUID `json:"id"`
-		Name     string    `json:"name"`
-		Tags     []string  `json:"tags"`
-		Path     string    `json:"path"`
-		FileName string    `json:"fileName"`
+		ID   uuid.UUID `json:"id"`
+		Name string    `json:"name"`
+		Tags []string  `json:"tags"`
+		Path string    `json:"path"`
+
+		MediaPath string `json:"mediaPath"`
+		FileName  string `json:"fileName"`
 
 		Build  reference.Reference   `json:"build"`
 		Addons []reference.Reference `json:"addons"`
 
-		SplashPath    string    `json:"splashPath"`
-		ThumbnailPath string    `json:"thumbnailPath"`
-		Version       string    `json:"version"`
-		UpdatedAt     time.Time `json:"updatedAt"`
+		Splash    *Media   `json:"splash"`
+		Thumbnail *Media   `json:"thumbnail"`
+		Media     []*Media `json:"media"`
+
+		Version   string    `json:"version"`
+		UpdatedAt time.Time `json:"updatedAt"`
 	}
 
 	GetProjectOpts struct {
@@ -53,11 +64,9 @@ type (
 	}
 
 	UpdateProjectOpts struct {
-		ID            uuid.UUID `json:"id"`
-		Name          *string   `json:"name"`
-		Tags          *[]string `json:"tags"`
-		ThumbnailPath *string   `json:"thumbnailPath"`
-		SplashPath    *string   `json:"splashPath"`
+		ID   uuid.UUID `json:"id"`
+		Name *string   `json:"name"`
+		Tags *[]string `json:"tags"`
 	}
 
 	AddProjectPackageOpts struct {
@@ -113,11 +122,10 @@ func (p *Project) Profile() *rbtypes.Profile {
 
 func (p *Project) Detail() *Detail {
 	return &Detail{
-		ID:            p.ID,
-		Name:          p.Name,
-		Tags:          p.Tags,
-		ThumbnailPath: p.ThumbnailPath,
-		SplashPath:    p.SplashPath,
+		ID:        p.ID,
+		Name:      p.Name,
+		Tags:      p.Tags,
+		MediaPath: p.MediaPath,
 	}
 }
 


### PR DESCRIPTION
- Switched projects to use a media folder defined in `rocketdesk.json` to use for media display within the application.
- Images / videos with the keyword `thumbnail` or `splash` are used as priory for those functions.
- Removed old splash and thumbnail paths from `rocketdesk.json`.