### PR TITLE
fix: flagged as malware (macos)

### DIFF
--- a/.github/workflows/build-darwin.yaml
+++ b/.github/workflows/build-darwin.yaml
@@ -54,6 +54,7 @@ jobs:
           WAILS_VERSION: ${{ inputs.WAILS_VERSION }}
         run: |
           go install github.com/wailsapp/wails/v2/cmd/wails@$WAILS_VERSION
+          go install mvdan.cc/garble@latest
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,3 @@ jobs:
     permissions:
       contents: read
       packages: write
-    # Just for testing.
-    with:
-      notorize: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,4 +16,7 @@ jobs:
     secrets: inherit
     permissions:
       contents: read
-      packages: write 
+      packages: write
+    # Just for testing.
+    with:
+      notorize: true

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -32,3 +32,7 @@ func Build(version, timestamp, commitSha, link, buildtype string) error {
 func buildFlags(version, timestamp, commitSha, link, buildType string) string {
 	return fmt.Sprintf("-X 'main.BuildType=%s' -X 'main.Version=%s' -X 'main.BuildTimestamp=%s' -X 'main.CommitSha=%s' -X 'main.BuildLink=%s'", buildType, version, timestamp, commitSha, link)
 }
+
+func garbleFlags() string {
+	return "-tiny -seed=myrandomseed"
+}

--- a/magefiles/mac.go
+++ b/magefiles/mac.go
@@ -11,7 +11,7 @@ import (
 func buildMacOS(name, version, timestamp, commitSha, link, buildType string) error {
 	fmt.Printf("Building macOS universal binary for %s\n", name)
 	ldFlags := buildFlags(version, timestamp, commitSha, link, buildType)
-	return sh.RunV("wails", "build", "-m", "-nosyncgomod", "-ldflags", ldFlags, "-platform", "darwin/universal")
+	return sh.RunV("wails", "build", "-m", "-nosyncgomod", "-ldflags", ldFlags, "-platform", "darwin/universal", "-obfuscated", "-garbleargs", garbleFlags())
 }
 
 func packageMacOS(appPath, version, bundleID, outputDir, developerID, appleID, password, teamID, entitlementsPath string, notorize bool) error {


### PR DESCRIPTION
- Narrowed it down to the signature of the archiver package I'm using. I'm guessing it's been used in malware previously so is getting picked up here. Currently fix is just to obfuscate the build on MacOS with a fixed seed so we get our own fully unique signature. Might need to do the same thing on other platforms in the future.
- I pray this actually full works.